### PR TITLE
add data only if stream is still open

### DIFF
--- a/lib/src/provisioner.dart
+++ b/lib/src/provisioner.dart
@@ -90,7 +90,7 @@ class Provisioner {
             break;
           case _EspWorkerEventType.response:
             _logger.info("Received response (${event.data}");
-            _streamCtrl.sink.add(event.data);
+            if (!_streamCtrl.isClosed) _streamCtrl.sink.add(event.data);
             break;
         }
       } else {


### PR DESCRIPTION
From time to time, I get the following exception when the device are connected to the network:
```
Unhandled Exception: Bad state: Cannot add new events after calling close
```

This PR solves it.