### PR TITLE
Optional BSSID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+- Parameter `bssid` of `ProvisioningRequest`s factory `fromStrings` is not required anymore. If ommited, `bssid` will default to `00:00:00:00:00:00`. 
+
 ## 2.0.2
 
 - Implemented CI/CD with GitHub Actions

--- a/example/esptouch_v2.dart
+++ b/example/esptouch_v2.dart
@@ -18,7 +18,7 @@ void main() async {
   try {
     await provisioner.start(ProvisioningRequest.fromStrings(
       ssid: "Renault 1.9D",
-      bssid: "f8:d1:11:bf:28:5c",
+      bssid: "f8:d1:11:bf:28:5c", // optional
       password: "renault19",
       reservedData: "Hello from Dart",
     ));

--- a/example/esptouch_v2_encryption.dart
+++ b/example/esptouch_v2_encryption.dart
@@ -18,7 +18,7 @@ void main() async {
   try {
     await provisioner.start(ProvisioningRequest.fromStrings(
       ssid: "Renault 1.9D",
-      bssid: "f8:d1:11:bf:28:5c",
+      bssid: "f8:d1:11:bf:28:5c", // optional
       password: "renault19",
       encryptionKey: "MySecretKey!6754",
     ));

--- a/example/example.dart
+++ b/example/example.dart
@@ -18,7 +18,7 @@ void main() async {
   try {
     await provisioner.start(ProvisioningRequest.fromStrings(
       ssid: "Renault 1.9D",
-      bssid: "f8:d1:11:bf:28:5c",
+      bssid: "f8:d1:11:bf:28:5c", // optional
       password: "renault19",
     ));
 

--- a/lib/src/provisioning_request.dart
+++ b/lib/src/provisioning_request.dart
@@ -41,7 +41,7 @@ class ProvisioningRequest {
   /// [bssid] shoud be in format aa:bb:cc:dd:ee:ff
   factory ProvisioningRequest.fromStrings({
     required String ssid,
-    required String bssid,
+    String bssid = '00:00:00:00:00:00',
     String? password,
     String? reservedData,
     String? encryptionKey,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esp_smartconfig
 description: EspTouch and EspTouchV2 implementations of SmartConfig provisioning protocols. Plain Dart. All platforms.
-version: 2.0.2
+version: 2.0.3
 homepage: https://abobija.com
 repository: https://github.com/abobija/esp-smartconfig-dart
 


### PR DESCRIPTION
Parameter `bssid` of `ProvisioningRequest`s factory `fromStrings` is not required anymore. If ommited, `bssid` will default to `00:00:00:00:00:00`. 