### PR TITLE
fix : Add IP address extraction to provisioning response

### DIFF
--- a/lib/src/protocol.dart
+++ b/lib/src/protocol.dart
@@ -127,7 +127,10 @@ abstract class Protocol {
   /// Receive data and returns response with device BSSID
   ///
   /// Throws [InvalidProvisioningResponseDataException] if data of received response is invalid
-  ProvisioningResponse receive(Uint8List data) {
+  ///
+  /// Added optional [sourceAddress] so derived protocols can extract IP address
+  /// from the UDP packet source when available.
+  ProvisioningResponse receive(Uint8List data, [InternetAddress? sourceAddress]) {
     if (data.length < 7) {
       throw InvalidProvisioningResponseDataException(
           "Invalid data ($data). Length should be at least 7 elements");

--- a/lib/src/protocol.dart
+++ b/lib/src/protocol.dart
@@ -130,7 +130,8 @@ abstract class Protocol {
   ///
   /// Added optional [sourceAddress] so derived protocols can extract IP address
   /// from the UDP packet source when available.
-  ProvisioningResponse receive(Uint8List data, [InternetAddress? sourceAddress]) {
+  ProvisioningResponse receive(Uint8List data,
+      [InternetAddress? sourceAddress]) {
     if (data.length < 7) {
       throw InvalidProvisioningResponseDataException(
           "Invalid data ($data). Length should be at least 7 elements");

--- a/lib/src/protocols/esptouch.dart
+++ b/lib/src/protocols/esptouch.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:esp_smartconfig/esp_smartconfig.dart';
@@ -85,8 +86,11 @@ class EspTouch extends Protocol {
   /// Receive data and returns response with device BSSID and IP address
   ///
   /// Throws [InvalidProvisioningResponseDataException] if received data is not valid
+  ///
+  /// Signature updated to match [Protocol.receive] and support optional
+  /// source address forwarding from [Provisioner].
   @override
-  ProvisioningResponse receive(Uint8List data) {
+  ProvisioningResponse receive(Uint8List data, [InternetAddress? sourceAddress]) {
     final response = super.receive(data);
 
     if (data[0] != _expectedResponseFirstByte) {

--- a/lib/src/protocols/esptouch.dart
+++ b/lib/src/protocols/esptouch.dart
@@ -90,7 +90,8 @@ class EspTouch extends Protocol {
   /// Signature updated to match [Protocol.receive] and support optional
   /// source address forwarding from [Provisioner].
   @override
-  ProvisioningResponse receive(Uint8List data, [InternetAddress? sourceAddress]) {
+  ProvisioningResponse receive(Uint8List data,
+      [InternetAddress? sourceAddress]) {
     final response = super.receive(data);
 
     if (data[0] != _expectedResponseFirstByte) {

--- a/lib/src/protocols/esptouch_v2.dart
+++ b/lib/src/protocols/esptouch_v2.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:esp_smartconfig/src/exceptions.dart';
 import 'package:esp_smartconfig/src/protocol.dart';
+import 'package:esp_smartconfig/src/provisioning_response.dart';
 
 class EspTouchV2 extends Protocol {
   static final version = 0;
@@ -10,6 +13,38 @@ class EspTouchV2 extends Protocol {
 
   @override
   List<int> get ports => [18266, 28266, 38266, 48266];
+
+  /// Receive data and returns response with device BSSID and IP address
+  ///
+  /// Implementation follows official Espressif EsptouchForAndroid:
+  /// - BSSID is extracted from response packet bytes 1-6
+  /// - IP address is extracted from UDP packet source address
+  ///
+  /// Throws [InvalidProvisioningResponseDataException] if received data is not valid
+  @override
+  ProvisioningResponse receive(Uint8List data, InternetAddress? sourceAddress) {
+    if (data.length < 7) {
+      throw InvalidProvisioningResponseDataException(
+          "Invalid data ($data). Length should be at least 7 elements");
+    }
+
+    // Extract BSSID from bytes 1-6
+    final response = ProvisioningResponse(Uint8List(6)..setAll(0, data.skip(1).take(6)));
+
+    // Extract IP from UDP packet source address (Official Espressif method)
+    if (sourceAddress != null && sourceAddress.type == InternetAddressType.IPv4) {
+      try {
+        final ipBytes = sourceAddress.rawAddress;
+        if (ipBytes.length == 4) {
+          response.ipAddress = Uint8List.fromList(ipBytes);
+        }
+      } catch (e) {
+        //
+      }
+    }
+
+    return response;
+  }
 
   late Int8List _buffer;
 

--- a/lib/src/protocols/esptouch_v2.dart
+++ b/lib/src/protocols/esptouch_v2.dart
@@ -14,33 +14,28 @@ class EspTouchV2 extends Protocol {
   @override
   List<int> get ports => [18266, 28266, 38266, 48266];
 
-  /// Receive data and returns response with device BSSID and IP address
-  ///
-  /// Implementation follows official Espressif EsptouchForAndroid:
-  /// - BSSID is extracted from response packet bytes 1-6
-  /// - IP address is extracted from UDP packet source address
-  ///
-  /// Throws [InvalidProvisioningResponseDataException] if received data is not valid
   @override
   ProvisioningResponse receive(Uint8List data, InternetAddress? sourceAddress) {
     if (data.length < 7) {
       throw InvalidProvisioningResponseDataException(
-          "Invalid data ($data). Length should be at least 7 elements");
+        "Invalid data ($data). Length should be at least 7 elements",
+      );
     }
 
-    // Extract BSSID from bytes 1-6
-    final response = ProvisioningResponse(Uint8List(6)..setAll(0, data.skip(1).take(6)));
+    final response = ProvisioningResponse(
+      Uint8List(6)..setAll(0, data.skip(1).take(6)),
+    );
 
     // Extract IP from UDP packet source address (Official Espressif method)
-    if (sourceAddress != null && sourceAddress.type == InternetAddressType.IPv4) {
+    // Implementation follows official Espressif EsptouchForAndroid:
+    if (sourceAddress != null &&
+        sourceAddress.type == InternetAddressType.IPv4) {
       try {
         final ipBytes = sourceAddress.rawAddress;
         if (ipBytes.length == 4) {
           response.ipAddress = Uint8List.fromList(ipBytes);
         }
-      } catch (e) {
-        //
-      }
+      } catch (e) {}
     }
 
     return response;
@@ -102,8 +97,10 @@ class EspTouchV2 extends Protocol {
         plainData.addAll(request.reservedData!);
       }
 
-      final encryptedData =
-          encrypt(Int8List.fromList(plainData), request.encryptionKey!);
+      final encryptedData = encrypt(
+        Int8List.fromList(plainData),
+        request.encryptionKey!,
+      );
 
       plainData.clear();
 
@@ -131,8 +128,10 @@ class EspTouchV2 extends Protocol {
         dataTmp.addAll(request.reservedData!);
 
         if (_isPasswordEncoded || _isReservedDataEncoded) {
-          final padding =
-              _padding(_reservedPaddingFactor, request.reservedData);
+          final padding = _padding(
+            _reservedPaddingFactor,
+            request.reservedData,
+          );
           _reservedDataPaddingLength = padding.length;
           dataTmp.addAll(padding);
         }
@@ -174,8 +173,9 @@ class EspTouchV2 extends Protocol {
       }
 
       final buf = Int8List(6);
-      final read =
-          Int8List.fromList(_buffer.skip(offset).take(expectLength).toList());
+      final read = Int8List.fromList(
+        _buffer.skip(offset).take(expectLength).toList(),
+      );
       buf.setAll(0, read);
       if (read.isEmpty) {
         break;
@@ -212,7 +212,8 @@ class EspTouchV2 extends Protocol {
     } else {
       isReservedDataEncoded = isEncoded(request.reservedData!);
       headTmp.add(
-          request.reservedData!.length | (_isReservedDataEncoded ? 0x80 : 0));
+        request.reservedData!.length | (_isReservedDataEncoded ? 0x80 : 0),
+      );
     }
 
     headTmp.add(crc(request.bssid));
@@ -238,25 +239,20 @@ class EspTouchV2 extends Protocol {
   }
 
   void _createBlocksFor6Bytes(
-      Int8List buf, int sequence, int crc, bool tailIsCrc) {
+    Int8List buf,
+    int sequence,
+    int crc,
+    bool tailIsCrc,
+  ) {
     if (sequence == -1) {
       // first sequence
       final syncBlock = _syncBlock();
 
-      blocks.addAll([
-        syncBlock,
-        0,
-        syncBlock,
-        0,
-      ]);
+      blocks.addAll([syncBlock, 0, syncBlock, 0]);
     } else {
       final seqBlock = _seqBlock(sequence);
 
-      blocks.addAll([
-        seqBlock,
-        seqBlock,
-        seqBlock,
-      ]);
+      blocks.addAll([seqBlock, seqBlock, seqBlock]);
     }
 
     for (int bit = 0; bit < (tailIsCrc ? 7 : 8); bit++) {

--- a/lib/src/protocols/esptouch_v2.dart
+++ b/lib/src/protocols/esptouch_v2.dart
@@ -4,12 +4,15 @@ import 'dart:typed_data';
 import 'package:esp_smartconfig/src/exceptions.dart';
 import 'package:esp_smartconfig/src/protocol.dart';
 import 'package:esp_smartconfig/src/provisioning_response.dart';
+import 'package:logging/logging.dart';
 
 class EspTouchV2 extends Protocol {
   static final version = 0;
 
   @override
   String get name => "EspTouch V2";
+
+  static final _logger = Logger("esptouch_v2");
 
   @override
   List<int> get ports => [18266, 28266, 38266, 48266];
@@ -35,7 +38,10 @@ class EspTouchV2 extends Protocol {
         if (ipBytes.length == 4) {
           response.ipAddress = Uint8List.fromList(ipBytes);
         }
-      } catch (e) {}
+      } catch (e, stackTrace) {
+        _logger.severe(
+            'Failed to extract IP address from source', e, stackTrace);
+      }
     }
 
     return response;

--- a/lib/src/protocols/esptouch_v2.dart
+++ b/lib/src/protocols/esptouch_v2.dart
@@ -18,7 +18,8 @@ class EspTouchV2 extends Protocol {
   List<int> get ports => [18266, 28266, 38266, 48266];
 
   @override
-  ProvisioningResponse receive(Uint8List data, InternetAddress? sourceAddress) {
+  ProvisioningResponse receive(Uint8List data, [InternetAddress? sourceAddress]) {
+  // Allow optional source address to be passed through from Provisioner.
     if (data.length < 7) {
       throw InvalidProvisioningResponseDataException(
         "Invalid data ($data). Length should be at least 7 elements",

--- a/lib/src/protocols/esptouch_v2.dart
+++ b/lib/src/protocols/esptouch_v2.dart
@@ -18,8 +18,9 @@ class EspTouchV2 extends Protocol {
   List<int> get ports => [18266, 28266, 38266, 48266];
 
   @override
-  ProvisioningResponse receive(Uint8List data, [InternetAddress? sourceAddress]) {
-  // Allow optional source address to be passed through from Provisioner.
+  ProvisioningResponse receive(Uint8List data,
+      [InternetAddress? sourceAddress]) {
+    // Allow optional source address to be passed through from Provisioner.
     if (data.length < 7) {
       throw InvalidProvisioningResponseDataException(
         "Invalid data ($data). Length should be at least 7 elements",

--- a/lib/src/provisioner.dart
+++ b/lib/src/provisioner.dart
@@ -155,7 +155,9 @@ class Provisioner {
             }
 
             try {
-              final response = protocol.receive(pkg.data);
+              // Pass the UDP packet source address to protocol.receive so V2
+              // protocols can extract the device IP from the response.
+              final response = protocol.receive(pkg.data, pkg.address);
 
               if (protocol.findResponse(response) != null) {
                 // Same response already received


### PR DESCRIPTION
- Extract device IP from UDP packet source address
- Follow official Espressif EsptouchForAndroid implementation
- Add IP address field to ProvisioningResponse
- Handle IPv4 address extraction with error handling

Fixes missing IP address that was previously not being captured from the EspTouchV2 provisioning response packets.
